### PR TITLE
Force Travis CI to use supports-color@3.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ node_js:
 
 before_install:
   - npm install supports-color@3.2.3 nan bindings mocha should
+  - rm -rf node_modules/mocha/node_modules/supports-color

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ node_js:
   - 'stable'
 
 before_install:
-  - npm install supports-color@3.1.2 nan bindings mocha should
+  - npm install supports-color@3.2.3 nan bindings mocha should

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ node_js:
   - 'stable'
 
 before_install:
-  - npm install supports-color nan bindings mocha should
+  - npm install supports-color@3.1.2 nan bindings mocha should

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^4.0.0",
     "should": "^13.0.0",
-    "supports-color": "=3.1.2"
+    "supports-color": "=3.2.3"
   },
   "gypfile": true
 }


### PR DESCRIPTION
later versions break node.js versions 0.10.x & 0.12.x