### PR TITLE
package.json: unpin `supports-color`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
   "devDependencies": {
     "mkdirp": "^0.5.1",
     "mocha": "^4.0.0",
-    "should": "^13.0.0",
-    "supports-color": "=3.2.3"
+    "should": "^13.0.0"
   },
   "gypfile": true
 }


### PR DESCRIPTION
The older version (3.2.3) of `supports-color` is only needed by Travis CI when building for Node.js 0.10.x and 0.12.x
This doesn't affect other users, so remove it from `package.json` and keep this only in `.travis.yml`

Signed-off-by: Michael Ira Krufky <mkrufky@gmail.com>