### PR TITLE
.travis.yml: allow failures on Node.js 0.10 & 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ node_js:
   - '9'
   - 'stable'
 
+allow_failures:
+  - node_js: '0.10'
+  - node_js: '0.12'
+
 before_install:
-  - npm install supports-color@3.2.3 nan bindings mocha should
-  - rm -rf node_modules/mocha/node_modules/supports-color
+  - npm install nan bindings mocha should

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ node_js:
   - '9'
   - 'stable'
 
-allow_failures:
-  - node_js: '0.10'
-  - node_js: '0.12'
+env:
+matrix:
+  allow_failures:
+    - node_js: '0.10'
+    - node_js: '0.12'
 
 before_install:
   - npm install nan bindings mocha should


### PR DESCRIPTION
`mocha` is being persistent about it's requirement for the latest `supports-color`, which no longer supports Node.js versions 0.10.x and 0.12.x

Rather than cooking up more hacks to allow the older versions to pass the tests, just allow them to fail without affecting the overall test outcome.

The build tests on Travis CI will continue to be useful, but the mocha tests will likely fail.

Signed-off-by: Michael Ira Krufky <mkrufky@gmail.com>