### PR TITLE
.travis.yml: build osx node 0.12 only once using osx_image: xcode7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ os:
   - linux
   - osx
 
-osx_image: xcode7.3
-
 language: node_js
 node_js:
   - '0.10'
@@ -20,6 +18,9 @@ node_js:
 
 env:
 matrix:
+  include:
+    - node_js: '0.12'
+      osx_image: xcode7.3
   allow_failures:
     - node_js: '0.10'
     - node_js: '0.12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,12 @@ node_js:
 
 env:
 matrix:
+  exclude:
+    - node_js: '0.12'
+      os: osx
   include:
     - node_js: '0.12'
+      os: osx
       osx_image: xcode7.3
   allow_failures:
     - node_js: '0.10'


### PR DESCRIPTION
only set osx_image: xcode7.3 when we're building for Node.js 0.12 on OSX