### PR TITLE
 parser: replace new `Buffer(0)` with `Buffer.allocUnsafe(0)` 

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,7 +50,7 @@ var Parser = function (options) {
     objectMode: !self.options.passThru
   })
 
-  self._buffer = Buffer.alloc(0)
+  self._buffer = Buffer.allocUnsafe(0)
 
   var feed_progress = (self.options.passThru) ?
     function(a, b, c) {
@@ -140,7 +140,7 @@ Parser.prototype._flush = function (done) {
   // don't bother sending partial packets to the TS Parser- they'll just get dropped
   if ((self.options.passThru) && (self._buffer.length > 0)) {
     self.push(self._buffer)
-    self._buffer = Buffer.alloc(0)
+    self._buffer = Buffer.allocUnsafe(0)
   }
   done()
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,7 +50,7 @@ var Parser = function (options) {
     objectMode: !self.options.passThru
   })
 
-  self._buffer = new Buffer(0)
+  self._buffer = Buffer.alloc(0)
 
   var feed_progress = (self.options.passThru) ?
     function(a, b, c) {
@@ -140,7 +140,7 @@ Parser.prototype._flush = function (done) {
   // don't bother sending partial packets to the TS Parser- they'll just get dropped
   if ((self.options.passThru) && (self._buffer.length > 0)) {
     self.push(self._buffer)
-    self._buffer = new Buffer(0)
+    self._buffer = Buffer.alloc(0)
   }
   done()
 }


### PR DESCRIPTION
Fixes the following warning generated by Node.js 10.x:

(node:26052) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Since we're allocating an empty Buffer, we don't have to initialize it, so we use `Buffer.allocUnsafe(0)` rather than `Buffer.alloc(0)`

Signed-off-by: Michael Ira Krufky <mkrufky@gmail.com>