### PR TITLE
deps/libdvbtee.gyp: define 'USE_WSTRING_CONVERT' when 'OS=="mac"'

### DIFF
--- a/deps/libdvbtee.gyp
+++ b/deps/libdvbtee.gyp
@@ -105,6 +105,9 @@
       'conditions': [
         ['OS=="mac"',
           {
+            'defines': [
+              'USE_WSTRING_CONVERT'
+            ],
             'link_settings': {
               'libraries': [
                 '-liconv'


### PR DESCRIPTION
It looks like `std::wstring_convert` is the only cross-platform method that can successfully convert between `std::string` and `std::wstring` without blowing up `v8::JSON::Parse`

Unfortunately, it's not always available under Linux and I haven't found a reliable way to test for it's support...  So this helps #25 on macOS but will have to remain open until a fix can be confirmed for all platforms.